### PR TITLE
chore: add arcade-agent.dev launch to Latest Updates

### DIFF
--- a/_data/updates.yml
+++ b/_data/updates.yml
@@ -1,3 +1,5 @@
+- date: "Jul 2026"
+  content: "Launched <a href=\"https://arcade-agent.dev\" target=\"_blank\">arcade-agent.dev</a>, the site for <a href=\"https://github.com/lemduc/arcade-agent\" target=\"_blank\">arcade-agent</a> — an open-source tool that gives coding agents bounded architectural context (via MCP) plus CI architecture-drift detection."
 - date: "June 2026"
   content: "Joined Vinsmart Future as Engineering Director in Hanoi, Vietnam, leading the engineering organization and setting technical strategy and direction."
 - date: "May 2026"


### PR DESCRIPTION
Adds a dated entry to the **Latest Updates** section (`_data/updates.yml`) announcing the launch of [arcade-agent.dev](https://arcade-agent.dev), the site for the open-source [arcade-agent](https://github.com/lemduc/arcade-agent) project.

- Single new entry at the top of the reverse-chronological list, matching the existing `date` + HTML `content` convention.
- Date: **Jul 2026** (launched 2026-07-21).
- No other changes.